### PR TITLE
Fix python-build `brew: command not found` error

### DIFF
--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -1537,6 +1537,7 @@ has_broken_mac_openssl() {
 }
 
 use_homebrew_openssl() {
+  command -v brew >/dev/null || return 1
   for openssl in ${PYTHON_BUILD_HOMEBREW_OPENSSL_FORMULA:-openssl}; do
     local ssldir="$(brew --prefix "${openssl}" || true)"
     if [ -d "$ssldir" ]; then


### PR DESCRIPTION
### Prerequisite
* [x] Please consider implementing the feature as a hook script or plugin as a first step.
  * Not applicable.
* [x] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.

The upstream [`has_broken_mac_openssl` function](https://github.com/rbenv/ruby-build/blob/7ec5e411bfc60df9c6df65f8fd7e9b5b38ec2fc6/bin/ruby-build#L1021) does not seem to call the [`use_homebrew_openssl` function](https://github.com/rbenv/ruby-build/blob/7ec5e411bfc60df9c6df65f8fd7e9b5b38ec2fc6/bin/ruby-build#L1028) directly. python-build on the other hand, directly calls this function in the templates.

* [x] My PR addresses the following *python-build* issue (if any)
  - This PR fixes (currently harmless) warning on macOS when homebrew is *not* installed.

### Description
- [x] Here are some details about my PR

For example:

```sh
wadkar$ pyenv install 3.8.2
/Users/wadkar/.pyenv/plugins/python-build/bin/python-build: line 1541: brew: command not found
/Users/wadkar/.pyenv/plugins/python-build/bin/python-build: line 1541: brew: command not found
Installing openssl-1.1.0j...
Installed openssl-1.1.0j to /Users/wadkar/.pyenv/versions/3.8.2

Installing readline-8.0...
Installed readline-8.0 to /Users/wadkar/.pyenv/versions/3.8.2

Installing Python-3.8.2...
python-build: use zlib from xcode sdk
Installed Python-3.8.2 to /Users/wadkar/.pyenv/versions/3.8.2
```

### Tests
- [ ] My PR adds the following unit tests (if any)

I am not sure if this PR is the right place to add a test at `@test "python-build succeeds on macOS without homebrew"` level. But iI would be happy to add it with some guidance. For example, how do I test for lack of `brew: command not found` in the build_log? Should I also assert for both `readlink` and `openssl` are built?
